### PR TITLE
change host to pdf viewer

### DIFF
--- a/src/lib/Player/index.js
+++ b/src/lib/Player/index.js
@@ -152,7 +152,7 @@ const MediaComp = ({ mediaURL, mediaType, config, posterUrl }) => {
         id="pdf-iframe"
         allowFullScreen
         className="w-full h-64 md:h-72 lg:h-96"
-        src={`https://d1jjf9b695fxyn.cloudfront.net/pdf/web/viewer.html?file=${encodeURIComponent(mediaURL)}`}
+        src={`https://darkblockio.github.io/pdf.viewer.io/pdfjs/web/viewer.html?file=${encodeURIComponent(mediaURL)}`}
       />
     )
   }


### PR DESCRIPTION
The new host is: 
`https://darkblockio.github.io/pdf.viewer.io/pdfjs/web/viewer.html?file=https%3A%2F%2Fdarkblock-media.s3.amazonaws.com%2Fsamples%2Fdocument.pdf`

![image](https://user-images.githubusercontent.com/97113254/190706295-f01d93f2-9b7b-4d97-9e15-9b6fc3b5ff0f.png)
