### PR TITLE
fix mobile height & center navigation arrows

### DIFF
--- a/src/lib/Player/Player.css
+++ b/src/lib/Player/Player.css
@@ -75,7 +75,7 @@
 }
 
 .Darkblock-playerBtn {
-  @apply w-6 h-6 p-2 mx-6 text-neutral-300;
+  @apply w-8 h-8 mx-6;
 }
 
 .Darkblock-playerBtnDisabled {
@@ -83,5 +83,5 @@
 }
 
 .Darkblock-arrowIcons {
-  @apply w-4 h-4 p-2;
+  @apply m-auto;
 }

--- a/src/lib/Stack/index.js
+++ b/src/lib/Stack/index.js
@@ -119,6 +119,8 @@ const Stack = ({ state = null, authenticate, urls, config }) => {
   const [opacity, setOpacity] = useState(0.4)
   const [showDetails, setShowDetails] = useState(false)
   const [detailDB, setDetailDB] = useState(null)
+  const [height, setHeight] = useState(window.innerHeight)
+  const doc = document.documentElement
 
   const handleOnClose = (e) => {
     e.preventDefault()
@@ -184,6 +186,19 @@ const Stack = ({ state = null, authenticate, urls, config }) => {
     setSwapping(true)
     setSelected({ type: nextDb.fileFormat, mediaURL: urls[nextIndex], i: nextIndex, db: nextDb })
   }
+
+  const documentHeight = () => {
+    setHeight(window.innerHeight)
+    doc.style.setProperty('--doc-height', `${window.innerHeight}px`)
+  }
+
+  useEffect(() => {
+    doc.style.setProperty('--doc-height', `${window.innerHeight}px`)
+    window.addEventListener('resize', documentHeight)
+    return () => {
+      window.removeEventListener('resize', documentHeight)
+    }
+  }, [height])
 
   return (
     <>

--- a/src/lib/playerModal.css
+++ b/src/lib/playerModal.css
@@ -1,5 +1,9 @@
+:root {
+  --doc-height: 100%;
+}
+
 .Darkblock-container {
-  @apply flex justify-center items-center overflow-x-hidden overflow-y-auto fixed inset-0 outline-none focus:outline-none z-50 absolute bg-[rgb(43,43,43)];
+  @apply flex justify-center items-center overflow-x-hidden overflow-y-auto inset-0 outline-none focus:outline-none z-50 absolute bg-[rgb(43,43,43)];
 }
 
 .modal-bg-darkblock {
@@ -7,7 +11,7 @@
 }
 
 .Darkblock-content {
-  @apply block w-full h-auto mx-auto text-center text-white;
+  @apply block w-full mx-auto text-center text-white; /* h-auto */
 }
 
 .Darkblock-awesomePlayerButton {
@@ -15,7 +19,8 @@
 }
 
 .Darkblock-player-modal-container {
-  @apply flex flex-col justify-between h-screen;
+  @apply flex flex-col justify-between ;
+  height: var(--doc-height);
 }
 
 .Darkblock-player-modal-close-button {


### PR DESCRIPTION
# Fixed height issue in mobile devices 

This issue is present in Chrome and Safari, others browsers like Firefox, Opera and brave were working fine.

Note: Tested on Iphone

## Safari
![image](https://user-images.githubusercontent.com/97113254/201200092-761c4fce-fc1f-4a2b-b7d4-a6a3f04a345e.png)

## Chrome 
![image](https://user-images.githubusercontent.com/97113254/201200107-7b33562f-ccf5-49ab-9ed6-0d42809724ea.png)


